### PR TITLE
Fixathon: Add image alt text

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker's Contribution License Agreement in https://github.com/spryker/product-management/blob/d9ca3d5624ffcc3862aac94ceb3450fae8eb2421/CONTRIBUTING.md

--- a/data/translation/Zed/de_DE.csv
+++ b/data/translation/Zed/de_DE.csv
@@ -106,3 +106,5 @@ Price,Preis
 select,auswählen
 "Product name",Produktname
 Types,Typen
+Alt text small,Alt-Text klein
+Alt text large,Alt-Text groß

--- a/data/translation/Zed/en_US.csv
+++ b/data/translation/Zed/en_US.csv
@@ -106,3 +106,5 @@ Price,Price
 select,select
 "Product name","Product name"
 Types,Types
+Alt text small,Alt text small
+Alt text large,Alt text large

--- a/src/Spryker/Zed/ProductManagement/Communication/Form/Product/ImageCollectionForm.php
+++ b/src/Spryker/Zed/ProductManagement/Communication/Form/Product/ImageCollectionForm.php
@@ -66,6 +66,16 @@ class ImageCollectionForm extends AbstractSubForm
     /**
      * @var string
      */
+    public const FIELD_ALT_TEXT_SMALL = 'alt_text_small';
+
+    /**
+     * @var string
+     */
+    public const FIELD_ALT_TEXT_LARGE = 'alt_text_large';
+
+    /**
+     * @var string
+     */
     public const OPTION_IMAGE_PREVIEW_LARGE_URL = 'option_image_preview_large_url';
 
     /**
@@ -120,7 +130,9 @@ class ImageCollectionForm extends AbstractSubForm
             ->addImagePreviewField($builder, $options)
             ->addImageSmallField($builder, $options)
             ->addImageBigField($builder, $options)
-            ->addSortOrderField($builder, $options);
+            ->addSortOrderField($builder, $options)
+            ->addAltTextSmallField($builder, $options)
+            ->addAltTextLargeField($builder, $options);
     }
 
     /**
@@ -276,6 +288,52 @@ class ImageCollectionForm extends AbstractSubForm
                     'data-sort-order' => static::DEFAULT_SORT_ORDER_VALUE,
                 ],
             ]);
+
+        return $this;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array<string, mixed> $options
+     *
+     * @return $this
+     */
+    protected function addAltTextSmallField(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(static::FIELD_ALT_TEXT_SMALL, TextType::class, [
+            'required' => false,
+            'label' => 'Alt text small',
+            'constraints' => [
+                new Length([
+                    'min' => 0,
+                    'max' => 255,
+                ]),
+            ],
+            'sanitize_xss' => true,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @param array<string, mixed> $options
+     *
+     * @return $this
+     */
+    protected function addAltTextLargeField(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(static::FIELD_ALT_TEXT_LARGE, TextType::class, [
+            'required' => false,
+            'label' => 'Alt text large',
+            'constraints' => [
+                new Length([
+                    'min' => 0,
+                    'max' => 255,
+                ]),
+            ],
+            'sanitize_xss' => true,
+        ]);
 
         return $this;
     }

--- a/src/Spryker/Zed/ProductManagement/Presentation/_partials/product-image-collection-theme.twig
+++ b/src/Spryker/Zed/ProductManagement/Presentation/_partials/product-image-collection-theme.twig
@@ -13,6 +13,9 @@
             <div class="form-group">
                 {{ form_row(form.external_url_small) }}
             </div>
+            <div class="form-group">
+                {{ form_row(form.alt_text_small) }}
+            </div>
         </div>
         <div class="col-lg-6">
             <div class="form-group">
@@ -26,6 +29,9 @@
             </div>
             <div class="form-group">
                 {{ form_row(form.external_url_large) }}
+            </div>
+            <div class="form-group">
+                {{ form_row(form.alt_text_large) }}
             </div>
         </div>
         <div class="col-lg-12">


### PR DESCRIPTION
## PR Description
This PR and all included in Core PRs enable Spryker users to set HTML alt text for product images in small and large version.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/product-management/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
